### PR TITLE
Updated UCSBDiningCommonsMenu entity and UCSBDiningCommonsMenuRepository

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenu.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenu.java
@@ -18,9 +18,9 @@ import lombok.Builder;
 public class UCSBDiningCommonsMenu {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private long id; 
-  
+  private Long id; 
+
   private String diningCommonsCode;
   private String name;
-  private boolean station;
+  private String station;
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenu.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenu.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenu")
+public class UCSBDiningCommonsMenu {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id; 
+  
+  private String diningCommonsCode;
+  private String name;
+  private boolean station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBDiningCommonsMenuRepository extends CrudRepository<UCSBDate, Long> {
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuRepository.java
@@ -1,12 +1,11 @@
 package edu.ucsb.cs156.example.repositories;
 
-import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenu;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-
 @Repository
-public interface UCSBDiningCommonsMenuRepository extends CrudRepository<UCSBDate, Long> {
+public interface UCSBDiningCommonsMenuRepository extends CrudRepository<UCSBDiningCommonsMenu, Long> {
 
 }


### PR DESCRIPTION
In this PR, I updated the UCSBDIningCommonsMenu entity and UCSBDiningCommonsMenuRepository. 

Closes Issue #6

Passes all checks on github.

Screenshot of H2 console:
![image](https://github.com/ucsb-cs156-m23/team02-m23-10am-3/assets/91923759/62dc9c17-d761-486f-903a-0321cc7bb0b2)

Screenshot of localhost 8080:
![image](https://github.com/ucsb-cs156-m23/team02-m23-10am-3/assets/91923759/795f78dd-4d71-4d33-a1ea-2bd63207a5b5)

Screenshot of dokku deployment at https://team02-edwin-yee.dokku-06.cs.ucsb.edu/:
![image](https://github.com/ucsb-cs156-m23/team02-m23-10am-3/assets/91923759/4c25096b-e19c-41de-9296-632384e290d2)

Screenshot of my ucsbdiningcommonsmenu database in Postgres when using \dt:
![image](https://github.com/ucsb-cs156-m23/team02-m23-10am-3/assets/91923759/31fdf291-1b55-4d63-9000-39d6f691fac2)






